### PR TITLE
Set Auto Column Width default to false

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -8328,7 +8328,7 @@ void MainWindow::init_CopyPasteLine() {
     // Auto Col Width
 
     bool isAutoColWidth =
-        Reg.value(w->objectName() + "AutoColWidth", true).toBool();
+        Reg.value(w->objectName() + "AutoColWidth", false).toBool();
     set_AutoColWidth(w, isAutoColWidth);
 
     w->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -10297,7 +10297,7 @@ void MainWindow::init_AutoColumnWidth() {
     // Auto Col Width
 
     bool isAutoColWidth =
-        Reg.value(w->objectName() + "AutoColWidth", true).toBool();
+        Reg.value(w->objectName() + "AutoColWidth", false).toBool();
     set_AutoColWidth(w, isAutoColWidth);
   }
 }


### PR DESCRIPTION
Updated `Reg.value(w->objectName() + "AutoColWidth", false).toBool()` in `src/mainwindow.cpp` so that the default value for "Auto Column Width" is `false` (unchecked) when no user setting is present.

---
*PR created automatically by Jules for task [323514704945167096](https://jules.google.com/task/323514704945167096) started by @YBronst*