### PR TITLE
Set Auto Column Width default to false & min OpenCore version to 1.0.5

### DIFF
--- a/src/aboutdialog.cpp
+++ b/src/aboutdialog.cpp
@@ -8,8 +8,8 @@
 extern MainWindow* mw_one;
 extern QString strAppName, strIniFile;
 QString CurVersion = "20260209";
-QString ocVer = "0.8.8";
-QString ocVerDev = "0.8.9";
+QString ocVer = "1.0.5";
+QString ocVerDev = "1.0.5";
 QString ocFrom, ocFromDev, strOCFrom, strOCFromDev;
 bool blDEV = false;
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -8328,7 +8328,7 @@ void MainWindow::init_CopyPasteLine() {
     // Auto Col Width
 
     bool isAutoColWidth =
-        Reg.value(w->objectName() + "AutoColWidth", true).toBool();
+        Reg.value(w->objectName() + "AutoColWidth", false).toBool();
     set_AutoColWidth(w, isAutoColWidth);
 
     w->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -10297,7 +10297,7 @@ void MainWindow::init_AutoColumnWidth() {
     // Auto Col Width
 
     bool isAutoColWidth =
-        Reg.value(w->objectName() + "AutoColWidth", true).toBool();
+        Reg.value(w->objectName() + "AutoColWidth", false).toBool();
     set_AutoColWidth(w, isAutoColWidth);
   }
 }

--- a/src/syncocdialog.cpp
+++ b/src/syncocdialog.cpp
@@ -68,25 +68,7 @@ SyncOCDialog::SyncOCDialog(QWidget* parent)
         i, QHeaderView::ResizeToContents);
   }
 
-  ui->comboOCVersions->addItems(QStringList() << tr("Latest Version") << "0.7.8"
-                                              << "0.7.7"
-                                              << "0.7.6"
-                                              << "0.7.5"
-                                              << "0.7.4"
-                                              << "0.7.3"
-                                              << "0.7.2"
-                                              << "0.7.1"
-                                              << "0.7.0"
-                                              << "0.6.9"
-                                              << "0.6.8"
-                                              << "0.6.7"
-                                              << "0.6.6"
-                                              << "0.6.5"
-                                              << "0.6.4"
-                                              << "0.6.3"
-                                              << "0.6.2"
-
-  );
+  ui->comboOCVersions->addItems(QStringList() << tr("Latest Version") << "1.0.5");
   ui->comboOCVersions->clear();
   ui->editOCDevSource->lineEdit()->setText(
       Reg.value("DevSource", "https://github.com/dortania/build-repo")
@@ -539,7 +521,7 @@ void SyncOCDialog::init_Sync_OC_Table() {
     ui->editOCDevSource->setHidden(true);
     ui->btnImport->setHidden(true);
 
-    QString strDev = Reg.value("maxVer", "0.7.8").toString();
+    QString strDev = Reg.value("maxVer", "1.0.5").toString();
     if (strDev.contains(" ")) strDev = strDev.split(" ").at(0);
     if (strDev > ui->comboOCVersions->itemText(1)) {
       ui->comboOCVersions->clear();
@@ -551,7 +533,7 @@ void SyncOCDialog::init_Sync_OC_Table() {
         c0 = list.at(2);
         QStringList lver;
 
-        QString str0 = "061";
+        QString str0 = "104";
         QString str1 = a0 + b0 + c0;
         int start = str0.toInt();
         int end = str1.toInt() + 1;


### PR DESCRIPTION
1. Changed `Reg.value(w->objectName() + "AutoColWidth", false)` so Auto Column Width defaults to false.
2. Updated minimum supported OpenCore version to 1.0.5 across syncocdialog and aboutdialog.

---
*PR created automatically by Jules for task [323514704945167096](https://jules.google.com/task/323514704945167096) started by @YBronst*